### PR TITLE
Fix cmake related libsamplerate build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 -------------
 
 -------------
-This add-on contains basic dsp related parts to handle speaker delays, channel related volume amplification and as test example a input resample handling.
+This add-on contains basic dsp related parts to handle speaker delays, channel related volume amplification.
 
 As mode it support a Dolby Pro Logic II compatible multichannel downmix to stereo, which becomes available if only 2 channel output on Kodi is selected.</description>
 

--- a/adsp.basic/addon.xml
+++ b/adsp.basic/addon.xml
@@ -18,7 +18,7 @@
 	<extension point="kodi.addon.metadata">
 		<summary lang="en">Basic audio DSP processor</summary>
 		<description lang="en">
-This add-on contains basic dsp related parts to handle speaker delays, channel related volume amplification and as test example a input resample handling.
+This add-on contains basic dsp related parts to handle speaker delays, channel related volume amplification.
 
 As mode it support a Dolby Pro Logic II compatible multichannel downmix to stereo, which becomes available if only 2 channel output on Kodi is selected.</description>
 		<disclaimer lang="en">This addon is still in development to increase amount of features, e.g. speaker position changes.</disclaimer>

--- a/adsp.basic/resources/language/English/strings.po
+++ b/adsp.basic/resources/language/English/strings.po
@@ -23,9 +23,7 @@ msgctxt "#30000"
 msgid "Stereo - Dolby ProLogic II"
 msgstr ""
 
-msgctxt "#30001"
-msgid "Input resampler"
-msgstr ""
+# empty string 30001
 
 msgctxt "#30002"
 msgid "Performs a multichannel 5.1 downmix to stereo 2.0 in Dolby ProLogic II format"

--- a/src/filter/high_shelf.cpp
+++ b/src/filter/high_shelf.cpp
@@ -15,8 +15,8 @@
 #define Q_SCALE             32.0
 
 #if !defined(M_PI) && defined(TARGET_WINDOWS)
-	#define _USE_MATH_DEFINES 
-	#include <cmath>
+  #define _USE_MATH_DEFINES 
+  #include <cmath>
 #endif
 
 chighShelf::chighShelf(unsigned long Sample_Rate, unsigned long freq, float gain_, float pitch, float reso, float reso_gain) {


### PR DESCRIPTION
After system updates the cmake creation has failed with:

```
CMake Error at /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find libsamplerate (missing: LIBSAMPLERATE_LIBRARIES)
Call Stack (most recent call first):
  /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
  Findlibsamplerate.cmake:25 (find_package_handle_standard_args)
  CMakeLists.txt:11 (find_package)


-- Configuring incomplete, errors occurred!
```

The commit here has fixed it for me, but must also checked on other systems.
