### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 

--- a/adsp.basic/addon.xml.in
+++ b/adsp.basic/addon.xml.in
@@ -10,11 +10,7 @@
 	</requires>
 	<extension
 		point="kodi.adsp"
-		library_linux="adsp.basic.so"
-		library_osx="adsp.basic.dylib"
-		library_wingl="adsp.basic.dll"
-		library_windx="adsp.basic.dll"
-		library_android="libadsp.basic.so" />
+		library_@PLATFORM@="@LIBRARY_FILENAME@"/>
 	<extension point="kodi.addon.metadata">
 		<summary lang="en">Basic audio DSP processor</summary>
 		<description lang="en">
@@ -22,7 +18,7 @@ This add-on contains basic dsp related parts to handle speaker delays, channel r
 
 As mode it support a Dolby Pro Logic II compatible multichannel downmix to stereo, which becomes available if only 2 channel output on Kodi is selected.</description>
 		<disclaimer lang="en">This addon is still in development to increase amount of features, e.g. speaker position changes.</disclaimer>
-		<platform>all</platform>
+		<platform>@PLATFORM@</platform>
 		<license>GNU GENERAL PUBLIC LICENSE. Version 3, June 2007</license>
 		<forum></forum>
 		<website></website>

--- a/src/AudioDSPBasic.cpp
+++ b/src/AudioDSPBasic.cpp
@@ -20,12 +20,12 @@
 #include <math.h>
 #include <vector>
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
-#include "kodi/libKODI_guilib.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
+#include "libKODI_guilib.h"
 
 #include "addon.h"
-#include "kodi/util/XMLUtils.h"
+#include "util/XMLUtils.h"
 #include "p8-platform/util/util.h"
 #include "p8-platform/util/StdString.h"
 

--- a/src/AudioDSPBasic.h
+++ b/src/AudioDSPBasic.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <map>
 
-#include "kodi/kodi_adsp_types.h"
+#include "kodi_adsp_types.h"
 
 #include "p8-platform/threads/threads.h"
 #include "p8-platform/threads/mutex.h"

--- a/src/AudioDSPSettings.cpp
+++ b/src/AudioDSPSettings.cpp
@@ -17,11 +17,11 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
-#include "kodi/libKODI_guilib.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
+#include "libKODI_guilib.h"
 
-#include "kodi/util/XMLUtils.h"
+#include "util/XMLUtils.h"
 #include "p8-platform/util/util.h"
 #include "p8-platform/util/StdString.h"
 

--- a/src/DSPProcessMaster.cpp
+++ b/src/DSPProcessMaster.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
+#include "libXBMC_addon.h"
 #include "p8-platform/util/util.h"
 #include "p8-platform/util/StdString.h"
 

--- a/src/DSPProcessMaster.h
+++ b/src/DSPProcessMaster.h
@@ -18,7 +18,7 @@
  *
  */
 
-#include "kodi/kodi_adsp_types.h"
+#include "kodi_adsp_types.h"
 
 #define ID_MENU_SPEAKER_GAIN_SETUP                      1
 #define ID_MENU_SPEAKER_DISTANCE_SETUP                  2

--- a/src/GUIDialogSpeakerDistance.cpp
+++ b/src/GUIDialogSpeakerDistance.cpp
@@ -17,11 +17,11 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
-#include "kodi/libKODI_guilib.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
+#include "libKODI_guilib.h"
 
-#include "kodi/util/XMLUtils.h"
+#include "util/XMLUtils.h"
 #include "p8-platform/util/util.h"
 
 #include "GUIDialogSpeakerDistance.h"

--- a/src/GUIDialogSpeakerGain.cpp
+++ b/src/GUIDialogSpeakerGain.cpp
@@ -17,11 +17,11 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
-#include "kodi/libKODI_guilib.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
+#include "libKODI_guilib.h"
 
-#include "kodi/util/XMLUtils.h"
+#include "util/XMLUtils.h"
 #include "p8-platform/util/util.h"
 #include "p8-platform/util/StdString.h"
 

--- a/src/Process_Stereo/DSPProcessStereo.cpp
+++ b/src/Process_Stereo/DSPProcessStereo.cpp
@@ -22,8 +22,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
 
 #include "DSPProcessStereo.h"
 #include "../addon.h"

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 #include <string>
 #include "addon.h"
-#include "kodi/kodi_adsp_dll.h"
+#include "kodi_adsp_dll.h"
 #include "p8-platform/util/util.h"
 #include "p8-platform/util/StdString.h"
 #include "AudioDSPBasic.h"

--- a/src/addon.h
+++ b/src/addon.h
@@ -18,9 +18,9 @@
  *
  */
 
-#include "kodi/libXBMC_addon.h"
-#include "kodi/libKODI_adsp.h"
-#include "kodi/libKODI_guilib.h"
+#include "libXBMC_addon.h"
+#include "libKODI_adsp.h"
+#include "libKODI_guilib.h"
 
 extern bool                          m_bCreated;
 extern std::string                   g_strUserPath;


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in
